### PR TITLE
Bump version number to 2.5.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@ Feedstock license: BSD 3-Clause
 
 Summary: Cog: A code generator for executing Python snippets in source files.
 
+Cog is a file generation tool. It lets you use pieces of Python
+code as generators in your source files to generate whatever text
+you need.
 
+
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cogapp-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cogapp-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/cogapp-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cogapp-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/cogapp-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/cogapp-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cogapp/badges/version.svg)](https://anaconda.org/conda-forge/cogapp)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cogapp/badges/downloads.svg)](https://anaconda.org/conda-forge/cogapp)
 
 Installing cogapp
 =================
@@ -31,7 +46,6 @@ It is possible to list all of the versions of `cogapp` available on your platfor
 ```
 conda search cogapp --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +81,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cogapp-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cogapp-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/cogapp-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cogapp-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/cogapp-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/cogapp-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cogapp/badges/version.svg)](https://anaconda.org/conda-forge/cogapp)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cogapp/badges/downloads.svg)](https://anaconda.org/conda-forge/cogapp)
 
 
 Updating cogapp-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +57,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
-{% set version = "2.5" %}
-{% set sha256 = "b0c8efdc7d232b9e66064bae93c259946fdabad153a8c78025bc173f7245bfd7" %}
+{% set name = "cogapp" %}
+{% set version = "2.5.1" %}
+{% set sha256 = "f8cf2288fb5a2087eb4a00d8b347ddc86e9058d4ab26b8c868433eb401adfe1c" %}
 
 package:
-  name: cogapp
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: cogapp-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/c/cogapp/cogapp-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -29,7 +30,16 @@ test:
 about:
   home: http://nedbatchelder.com/code/cog
   license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
   summary: 'Cog: A code generator for executing Python snippets in source files.'
+
+  description: |
+    Cog is a file generation tool. It lets you use pieces of Python
+    code as generators in your source files to generate whatever text
+    you need.
+  doc_url: http://nedbatchelder.com/code/cog
+  dev_url: https://bitbucket.org/ned/cog
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
In addition to bumping the version number to 2.5.1, this PR includes the following changes:

- Add and use `name` variable as in example recipe
- Add `license_file` and `license_family` fields
- Add `description`, `doc_url` and `dev_url` fields
- Re-render with conda-smithy 1.6.1